### PR TITLE
ref(*): Refactors various functions and adds support for binary data

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ let mut macaroon = match Macaroon::create("location", b"key", "id") {
 // Add our first-party caveat. We say that only someone with account 12345678
 // is authorized to access whatever the macaroon is protecting
 // Note that we can add however many of these we want, with different predicates
-macaroon.add_first_party_caveat("account = 12345678");
+macaroon.add_first_party_caveat("account = 12345678".into());
 
 // Now we verify the macaroon
 // First we create the verifier
 let mut verifier = Verifier::new();
 
 // We assert that the account number is "12345678"
-verifier.satisfy_exact("account = 12345678");
+verifier.satisfy_exact("account = 12345678".into());
 
 // Now we verify the macaroon. It should return `Ok(true)` if the user is authorized
 match macaroon.verify(b"key", &mut verifier) {
@@ -85,19 +85,19 @@ match macaroon.verify(b"key", &mut verifier) {
 
 // Now, let's add a third-party caveat, which just says that we need our third party
 // to authorize this for us as well.
-macaroon.add_third_party_caveat("https://auth.mybank", b"different key", "caveat id");
+macaroon.add_third_party_caveat("https://auth.mybank", b"different key", "caveat id".into());
 
 // When we're ready to verify a third-party caveat, we use the location
 // (in this case, "https://auth.mybank") to retrieve the discharge macaroons we use to verify.
 // These would be created by the third party like so:
 let mut discharge = match Macaroon::create("http://auth.mybank/",
                                            b"different key",
-                                           "caveat id") {
+                                           "caveat id".into()) {
     Ok(discharge) => discharge,
     Err(error) => panic!("Error creating discharge macaroon: {:?}", error),
 };
 // And this is the criterion the third party requires for authorization
-discharge.add_first_party_caveat("account = 12345678");
+discharge.add_first_party_caveat("account = 12345678".into());
 
 // Once we receive the discharge macaroon, we bind it to the original macaroon
 macaroon.bind(&mut discharge);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,11 @@ impl Macaroon {
     ///
     /// # Errors
     /// Returns `MacaroonError::BadMacaroon` if the identifier is is empty
-    pub fn create(location: &str, key: &[u8], identifier: ByteString) -> Result<Macaroon, MacaroonError> {
+    pub fn create(
+        location: &str,
+        key: &[u8],
+        identifier: ByteString,
+    ) -> Result<Macaroon, MacaroonError> {
         let macaroon_key = crypto::generate_derived_key(key);
 
         let macaroon: Macaroon = Macaroon {
@@ -226,9 +230,9 @@ impl Macaroon {
         macaroon.validate()
     }
 
-    /// Returns the identifier for the macaroon
-    pub fn identifier(&self) -> &ByteString {
-        &self.identifier
+    /// Returns a clone of the identifier for the macaroon
+    pub fn identifier(&self) -> ByteString {
+        self.identifier.clone()
     }
 
     /// Returns the location for the macaroon
@@ -451,7 +455,8 @@ mod tests {
     #[test]
     fn create_invalid_macaroon() {
         let key: &[u8; 32] = b"this is a super duper secret key";
-        let macaroon_res: Result<Macaroon, MacaroonError> = Macaroon::create("location", key, "".into());
+        let macaroon_res: Result<Macaroon, MacaroonError> =
+            Macaroon::create("location", key, "".into());
         assert!(macaroon_res.is_err());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,14 +319,14 @@ impl Macaroon {
         match format {
             serialization::Format::V1 => serialization::v1::serialize(self),
             serialization::Format::V2 => serialization::v2::serialize(self),
-            serialization::Format::V2J => serialization::v2j::serialize_json(self),
+            serialization::Format::V2JSON => serialization::v2json::serialize(self),
         }
     }
 
     /// Deserialize a macaroon
     pub fn deserialize(data: &[u8]) -> Result<Macaroon, MacaroonError> {
         let macaroon: Macaroon = match data[0] as char {
-            '{' => serialization::v2j::deserialize_json(data)?,
+            '{' => serialization::v2json::deserialize(data)?,
             '\x02' => serialization::v2::deserialize(data)?,
             'a'..='z' | 'A'..='Z' | '0'..='9' | '+' | '-' | '/' | '_' => {
                 serialization::v1::deserialize(data)?

--- a/src/serialization/macaroon_builder.rs
+++ b/src/serialization/macaroon_builder.rs
@@ -1,10 +1,11 @@
 use caveat::Caveat;
 use error::MacaroonError;
+use ByteString;
 use Macaroon;
 
 #[derive(Default)]
 pub struct MacaroonBuilder {
-    identifier: String,
+    identifier: ByteString,
     location: Option<String>,
     signature: [u8; 32],
     caveats: Vec<Box<dyn Caveat>>,
@@ -15,8 +16,8 @@ impl MacaroonBuilder {
         Default::default()
     }
 
-    pub fn set_identifier(&mut self, identifier: &str) {
-        self.identifier = (*identifier).to_string();
+    pub fn set_identifier(&mut self, identifier: ByteString) {
+        self.identifier = identifier;
     }
 
     pub fn set_location(&mut self, location: &str) {
@@ -36,7 +37,7 @@ impl MacaroonBuilder {
     }
 
     pub fn build(&self) -> Result<Macaroon, MacaroonError> {
-        if self.identifier.is_empty() {
+        if self.identifier.0.is_empty() {
             return Err(MacaroonError::BadMacaroon("No identifier found"));
         }
         if self.signature.is_empty() {

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -1,10 +1,10 @@
 pub mod macaroon_builder;
 pub mod v1;
 pub mod v2;
-pub mod v2j;
+pub mod v2json;
 
 pub enum Format {
     V1,
     V2,
-    V2J,
+    V2JSON,
 }

--- a/src/serialization/v1.rs
+++ b/src/serialization/v1.rs
@@ -169,7 +169,7 @@ mod tests {
     use Macaroon;
 
     #[test]
-    fn test_deserialize_v1() {
+    fn test_deserialize() {
         let mut serialized = "MDAyMWxvY2F0aW9uIGh0dHA6Ly9leGFtcGxlLm9yZy8KMDAxNWlkZW50aWZpZXIga2V5aWQKMDAyZnNpZ25hdHVyZSB83ueSURxbxvUoSFgF3-myTnheKOKpkwH51xHGCeOO9wo";
         let mut signature: [u8; 32] = [
             124, 222, 231, 146, 81, 28, 91, 198, 245, 40, 72, 88, 5, 223, 233, 178, 78, 120, 94,
@@ -198,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deserialize_v1_two_caveats() {
+    fn test_deserialize_two_caveats() {
         let serialized = "MDAyMWxvY2F0aW9uIGh0dHA6Ly9leGFtcGxlLm9yZy8KMDAxNWlkZW50aWZpZXIga2V5aWQKMDAxZGNpZCBhY2NvdW50ID0gMzczNTkyODU1OQowMDE1Y2lkIHVzZXIgPSBhbGljZQowMDJmc2lnbmF0dXJlIEvpZ80eoMaya69qSpTumwWxWIbaC6hejEKpPI0OEl78Cg";
         let signature = [
             75, 233, 103, 205, 30, 160, 198, 178, 107, 175, 106, 74, 148, 238, 155, 5, 177, 88,
@@ -221,7 +221,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_deserialize_v1() {
+    fn test_serialize_deserialize() {
         let mut macaroon: Macaroon =
             Macaroon::create("http://example.org/", b"my key", "keyid").unwrap();
         macaroon.add_first_party_caveat("account = 3735928559");

--- a/src/serialization/v1.rs
+++ b/src/serialization/v1.rs
@@ -174,7 +174,7 @@ mod tests {
         let macaroon = super::deserialize(&serialized.as_bytes().to_vec()).unwrap();
         assert!(macaroon.location().is_some());
         assert_eq!("http://example.org/", &macaroon.location().unwrap());
-        assert_eq!(&ByteString::from("keyid"), macaroon.identifier());
+        assert_eq!(ByteString::from("keyid"), macaroon.identifier());
         assert_eq!(signature.to_vec(), macaroon.signature());
         serialized = "MDAyMWxvY2F0aW9uIGh0dHA6Ly9leGFtcGxlLm9yZy8KMDAxNWlkZW50aWZpZXIga2V5aWQKMDAxZGNpZCBhY2NvdW50ID0gMzczNTkyODU1OQowMDJmc2lnbmF0dXJlIPVIB_bcbt-Ivw9zBrOCJWKjYlM9v3M5umF2XaS9JZ2HCg";
         signature = [
@@ -184,7 +184,7 @@ mod tests {
         let macaroon = super::deserialize(&serialized.as_bytes().to_vec()).unwrap();
         assert!(macaroon.location().is_some());
         assert_eq!("http://example.org/", &macaroon.location().unwrap());
-        assert_eq!(&ByteString::from("keyid"), macaroon.identifier());
+        assert_eq!(ByteString::from("keyid"), macaroon.identifier());
         assert_eq!(1, macaroon.caveats().len());
         assert_eq!(
             ByteString::from("account = 3735928559"),
@@ -203,7 +203,7 @@ mod tests {
         let macaroon = super::deserialize(&serialized.as_bytes().to_vec()).unwrap();
         assert!(macaroon.location().is_some());
         assert_eq!("http://example.org/", &macaroon.location().unwrap());
-        assert_eq!(&ByteString::from("keyid"), macaroon.identifier());
+        assert_eq!(ByteString::from("keyid"), macaroon.identifier());
         assert_eq!(signature.to_vec(), macaroon.signature());
         assert_eq!(2, macaroon.caveats().len());
         assert_eq!(

--- a/src/serialization/v1.rs
+++ b/src/serialization/v1.rs
@@ -41,7 +41,7 @@ fn packet_header(size: usize) -> Vec<u8> {
     header
 }
 
-pub fn serialize_v1(macaroon: &Macaroon) -> Result<Vec<u8>, MacaroonError> {
+pub fn serialize(macaroon: &Macaroon) -> Result<Vec<u8>, MacaroonError> {
     let mut serialized: Vec<u8> = Vec::new();
     if let Some(ref location) = macaroon.location() {
         serialized.extend(serialize_as_packet(LOCATION, location.as_bytes()));
@@ -111,7 +111,7 @@ fn split_index(packet: &[u8]) -> Result<usize, MacaroonError> {
     }
 }
 
-pub fn deserialize_v1(base64: &[u8]) -> Result<Macaroon, MacaroonError> {
+pub fn deserialize(base64: &[u8]) -> Result<Macaroon, MacaroonError> {
     let data = base64_decode(&String::from_utf8(base64.to_vec())?)?;
     let mut builder: MacaroonBuilder = MacaroonBuilder::new();
     let mut caveat_builder: CaveatBuilder = CaveatBuilder::new();
@@ -175,7 +175,7 @@ mod tests {
             124, 222, 231, 146, 81, 28, 91, 198, 245, 40, 72, 88, 5, 223, 233, 178, 78, 120, 94,
             40, 226, 169, 147, 1, 249, 215, 17, 198, 9, 227, 142, 247,
         ];
-        let macaroon = super::deserialize_v1(&serialized.as_bytes().to_vec()).unwrap();
+        let macaroon = super::deserialize(&serialized.as_bytes().to_vec()).unwrap();
         assert!(macaroon.location().is_some());
         assert_eq!("http://example.org/", &macaroon.location().unwrap());
         assert_eq!("keyid", macaroon.identifier());
@@ -185,7 +185,7 @@ mod tests {
             245, 72, 7, 246, 220, 110, 223, 136, 191, 15, 115, 6, 179, 130, 37, 98, 163, 98, 83,
             61, 191, 115, 57, 186, 97, 118, 93, 164, 189, 37, 157, 135,
         ];
-        let macaroon = super::deserialize_v1(&serialized.as_bytes().to_vec()).unwrap();
+        let macaroon = super::deserialize(&serialized.as_bytes().to_vec()).unwrap();
         assert!(macaroon.location().is_some());
         assert_eq!("http://example.org/", &macaroon.location().unwrap());
         assert_eq!("keyid", macaroon.identifier());
@@ -204,7 +204,7 @@ mod tests {
             75, 233, 103, 205, 30, 160, 198, 178, 107, 175, 106, 74, 148, 238, 155, 5, 177, 88,
             134, 218, 11, 168, 94, 140, 66, 169, 60, 141, 14, 18, 94, 252,
         ];
-        let macaroon = super::deserialize_v1(&serialized.as_bytes().to_vec()).unwrap();
+        let macaroon = super::deserialize(&serialized.as_bytes().to_vec()).unwrap();
         assert!(macaroon.location().is_some());
         assert_eq!("http://example.org/", &macaroon.location().unwrap());
         assert_eq!("keyid", macaroon.identifier());

--- a/src/serialization/v2.rs
+++ b/src/serialization/v2.rs
@@ -30,7 +30,7 @@ fn serialize_field_v2(tag: u8, value: &[u8], buffer: &mut Vec<u8>) {
     buffer.extend(value);
 }
 
-pub fn serialize_v2(macaroon: &Macaroon) -> Result<Vec<u8>, MacaroonError> {
+pub fn serialize(macaroon: &Macaroon) -> Result<Vec<u8>, MacaroonError> {
     let mut buffer: Vec<u8> = Vec::new();
     buffer.push(2); // version
     if let Some(ref location) = macaroon.location() {
@@ -136,7 +136,7 @@ impl<'r> V2Deserializer<'r> {
     }
 }
 
-pub fn deserialize_v2(data: &[u8]) -> Result<Macaroon, MacaroonError> {
+pub fn deserialize(data: &[u8]) -> Result<Macaroon, MacaroonError> {
     let mut builder: MacaroonBuilder = MacaroonBuilder::new();
     let mut deserializer: V2Deserializer = V2Deserializer::new(data);
     if deserializer.get_byte()? != 2 {
@@ -252,7 +252,7 @@ mod tests {
             134, 218, 11, 168, 94, 140, 66, 169, 60, 141, 14, 18, 94, 252,
         ];
         let serialized: Vec<u8> = base64::decode_config(SERIALIZED, base64::URL_SAFE).unwrap();
-        let macaroon = super::deserialize_v2(&serialized).unwrap();
+        let macaroon = super::deserialize(&serialized).unwrap();
         assert_eq!("http://example.org/", &macaroon.location().unwrap());
         assert_eq!("keyid", macaroon.identifier());
         assert_eq!(2, macaroon.caveats().len());
@@ -280,7 +280,7 @@ mod tests {
         builder.set_location("http://example.org/");
         builder.set_identifier("keyid");
         builder.set_signature(&SIGNATURE);
-        let serialized = super::serialize_v2(&builder.build().unwrap()).unwrap();
+        let serialized = super::serialize(&builder.build().unwrap()).unwrap();
         assert_eq!(
             base64::decode_config(SERIALIZED, base64::URL_SAFE).unwrap(),
             serialized
@@ -293,8 +293,8 @@ mod tests {
         macaroon.add_first_party_caveat("account = 3735928559");
         macaroon.add_first_party_caveat("user = alice");
         macaroon.add_third_party_caveat("https://auth.mybank.com", b"caveat key", "caveat");
-        let serialized = super::serialize_v2(&macaroon).unwrap();
-        macaroon = super::deserialize_v2(&serialized).unwrap();
+        let serialized = super::serialize(&macaroon).unwrap();
+        macaroon = super::deserialize(&serialized).unwrap();
         assert_eq!("http://example.org/", &macaroon.location().unwrap());
         assert_eq!("keyid", macaroon.identifier());
         assert_eq!(3, macaroon.caveats().len());

--- a/src/serialization/v2.rs
+++ b/src/serialization/v2.rs
@@ -4,11 +4,11 @@ use serialization::macaroon_builder::MacaroonBuilder;
 use Macaroon;
 
 // Version 2 fields
-const EOS_V2: u8 = 0;
-const LOCATION_V2: u8 = 1;
-const IDENTIFIER_V2: u8 = 2;
-const VID_V2: u8 = 4;
-const SIGNATURE_V2: u8 = 6;
+const EOS: u8 = 0;
+const LOCATION: u8 = 1;
+const IDENTIFIER: u8 = 2;
+const VID: u8 = 4;
+const SIGNATURE: u8 = 6;
 
 const VARINT_PACK_SIZE: usize = 128;
 
@@ -24,7 +24,7 @@ fn varint_size(size: usize) -> Vec<u8> {
     buffer
 }
 
-fn serialize_field_v2(tag: u8, value: &[u8], buffer: &mut Vec<u8>) {
+fn serialize_field(tag: u8, value: &[u8], buffer: &mut Vec<u8>) {
     buffer.push(tag);
     buffer.extend(varint_size(value.len()));
     buffer.extend(value);
@@ -34,47 +34,47 @@ pub fn serialize(macaroon: &Macaroon) -> Result<Vec<u8>, MacaroonError> {
     let mut buffer: Vec<u8> = Vec::new();
     buffer.push(2); // version
     if let Some(ref location) = macaroon.location() {
-        serialize_field_v2(LOCATION_V2, &location.as_bytes().to_vec(), &mut buffer);
+        serialize_field(LOCATION, &location.as_bytes().to_vec(), &mut buffer);
     };
-    serialize_field_v2(
-        IDENTIFIER_V2,
+    serialize_field(
+        IDENTIFIER,
         &macaroon.identifier().as_bytes().to_vec(),
         &mut buffer,
     );
-    buffer.push(EOS_V2);
+    buffer.push(EOS);
     for caveat in macaroon.caveats() {
         match caveat.get_type() {
             CaveatType::FirstParty => {
                 let first_party = caveat.as_first_party().unwrap();
-                serialize_field_v2(
-                    IDENTIFIER_V2,
+                serialize_field(
+                    IDENTIFIER,
                     &first_party.predicate().as_bytes().to_vec(),
                     &mut buffer,
                 );
-                buffer.push(EOS_V2);
+                buffer.push(EOS);
             }
             CaveatType::ThirdParty => {
                 let third_party = caveat.as_third_party().unwrap();
-                serialize_field_v2(LOCATION_V2, third_party.location().as_bytes(), &mut buffer);
-                serialize_field_v2(IDENTIFIER_V2, third_party.id().as_bytes(), &mut buffer);
-                serialize_field_v2(VID_V2, third_party.verifier_id().as_slice(), &mut buffer);
-                buffer.push(EOS_V2);
+                serialize_field(LOCATION, third_party.location().as_bytes(), &mut buffer);
+                serialize_field(IDENTIFIER, third_party.id().as_bytes(), &mut buffer);
+                serialize_field(VID, third_party.verifier_id().as_slice(), &mut buffer);
+                buffer.push(EOS);
             }
         }
     }
-    buffer.push(EOS_V2);
-    serialize_field_v2(SIGNATURE_V2, macaroon.signature(), &mut buffer);
+    buffer.push(EOS);
+    serialize_field(SIGNATURE, macaroon.signature(), &mut buffer);
     Ok(buffer)
 }
 
-struct V2Deserializer<'r> {
+struct Deserializer<'r> {
     data: &'r [u8],
     index: usize,
 }
 
-impl<'r> V2Deserializer<'r> {
-    pub fn new(data: &[u8]) -> V2Deserializer {
-        V2Deserializer { data, index: 0 }
+impl<'r> Deserializer<'r> {
+    pub fn new(data: &[u8]) -> Deserializer {
+        Deserializer { data, index: 0 }
     }
 
     fn get_byte(&mut self) -> Result<u8, MacaroonError> {
@@ -95,7 +95,7 @@ impl<'r> V2Deserializer<'r> {
     pub fn get_eos(&mut self) -> Result<u8, MacaroonError> {
         let eos = self.get_byte()?;
         match eos {
-            EOS_V2 => Ok(eos),
+            EOS => Ok(eos),
             _ => Err(MacaroonError::DeserializationError(String::from(
                 "Expected EOS",
             ))),
@@ -138,7 +138,7 @@ impl<'r> V2Deserializer<'r> {
 
 pub fn deserialize(data: &[u8]) -> Result<Macaroon, MacaroonError> {
     let mut builder: MacaroonBuilder = MacaroonBuilder::new();
-    let mut deserializer: V2Deserializer = V2Deserializer::new(data);
+    let mut deserializer: Deserializer = Deserializer::new(data);
     if deserializer.get_byte()? != 2 {
         return Err(MacaroonError::DeserializationError(String::from(
             "Wrong version number",
@@ -146,8 +146,8 @@ pub fn deserialize(data: &[u8]) -> Result<Macaroon, MacaroonError> {
     }
     let mut tag: u8 = deserializer.get_tag()?;
     match tag {
-        LOCATION_V2 => builder.set_location(&String::from_utf8(deserializer.get_field()?)?),
-        IDENTIFIER_V2 => builder.set_identifier(&String::from_utf8(deserializer.get_field()?)?),
+        LOCATION => builder.set_location(&String::from_utf8(deserializer.get_field()?)?),
+        IDENTIFIER => builder.set_identifier(&String::from_utf8(deserializer.get_field()?)?),
         _ => {
             return Err(MacaroonError::DeserializationError(String::from(
                 "Identifier not found",
@@ -157,7 +157,7 @@ pub fn deserialize(data: &[u8]) -> Result<Macaroon, MacaroonError> {
     if builder.has_location() {
         tag = deserializer.get_tag()?;
         match tag {
-            IDENTIFIER_V2 => {
+            IDENTIFIER => {
                 builder.set_identifier(&String::from_utf8(deserializer.get_field()?)?);
             }
             _ => {
@@ -170,14 +170,14 @@ pub fn deserialize(data: &[u8]) -> Result<Macaroon, MacaroonError> {
     }
     deserializer.get_eos()?;
     tag = deserializer.get_tag()?;
-    while tag != EOS_V2 {
+    while tag != EOS {
         let mut caveat_builder: CaveatBuilder = CaveatBuilder::new();
         match tag {
-            LOCATION_V2 => {
+            LOCATION => {
                 let field: Vec<u8> = deserializer.get_field()?;
                 caveat_builder.add_location(String::from_utf8(field)?);
             }
-            IDENTIFIER_V2 => caveat_builder.add_id(String::from_utf8(deserializer.get_field()?)?),
+            IDENTIFIER => caveat_builder.add_id(String::from_utf8(deserializer.get_field()?)?),
             _ => {
                 return Err(MacaroonError::DeserializationError(String::from(
                     "Caveat identifier \
@@ -188,7 +188,7 @@ pub fn deserialize(data: &[u8]) -> Result<Macaroon, MacaroonError> {
         if caveat_builder.has_location() {
             tag = deserializer.get_tag()?;
             match tag {
-                IDENTIFIER_V2 => {
+                IDENTIFIER => {
                     let field: Vec<u8> = deserializer.get_field()?;
                     caveat_builder.add_id(String::from_utf8(field)?);
                 }
@@ -202,14 +202,14 @@ pub fn deserialize(data: &[u8]) -> Result<Macaroon, MacaroonError> {
         }
         tag = deserializer.get_tag()?;
         match tag {
-            VID_V2 => {
+            VID => {
                 let field: Vec<u8> = deserializer.get_field()?;
                 caveat_builder.add_verifier_id(field);
                 builder.add_caveat(caveat_builder.build()?);
                 deserializer.get_eos()?;
                 tag = deserializer.get_tag()?;
             }
-            EOS_V2 => {
+            EOS => {
                 builder.add_caveat(caveat_builder.build()?);
                 tag = deserializer.get_tag()?;
             }
@@ -222,7 +222,7 @@ pub fn deserialize(data: &[u8]) -> Result<Macaroon, MacaroonError> {
         }
     }
     tag = deserializer.get_tag()?;
-    if tag == SIGNATURE_V2 {
+    if tag == SIGNATURE {
         let sig: Vec<u8> = deserializer.get_field()?;
         if sig.len() != 32 {
             return Err(MacaroonError::DeserializationError(String::from(
@@ -245,7 +245,7 @@ mod tests {
     use Macaroon;
 
     #[test]
-    fn test_deserialize_v2() {
+    fn test_deserialize() {
         const SERIALIZED: &str = "AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe_A==";
         const SIGNATURE: [u8; 32] = [
             75, 233, 103, 205, 30, 160, 198, 178, 107, 175, 106, 74, 148, 238, 155, 5, 177, 88,
@@ -268,7 +268,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_v2() {
+    fn test_serialize() {
         const SERIALIZED: &str = "AgETaHR0cDovL2V4YW1wbGUub3JnLwIFa2V5aWQAAhRhY2NvdW50ID0gMzczNTkyODU1OQACDHVzZXIgPSBhbGljZQAABiBL6WfNHqDGsmuvakqU7psFsViG2guoXoxCqTyNDhJe_A==";
         const SIGNATURE: [u8; 32] = [
             75, 233, 103, 205, 30, 160, 198, 178, 107, 175, 106, 74, 148, 238, 155, 5, 177, 88,
@@ -288,7 +288,7 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_deserialize_v2() {
+    fn test_serialize_deserialize() {
         let mut macaroon = Macaroon::create("http://example.org/", b"key", "keyid").unwrap();
         macaroon.add_first_party_caveat("account = 3735928559");
         macaroon.add_first_party_caveat("user = alice");

--- a/src/serialization/v2.rs
+++ b/src/serialization/v2.rs
@@ -248,7 +248,7 @@ mod tests {
         let serialized: Vec<u8> = base64::decode_config(SERIALIZED, base64::URL_SAFE).unwrap();
         let macaroon = super::deserialize(&serialized).unwrap();
         assert_eq!("http://example.org/", &macaroon.location().unwrap());
-        assert_eq!(&ByteString::from("keyid"), macaroon.identifier());
+        assert_eq!(ByteString::from("keyid"), macaroon.identifier());
         assert_eq!(2, macaroon.caveats().len());
         assert_eq!(
             ByteString::from("account = 3735928559"),
@@ -292,7 +292,7 @@ mod tests {
         let serialized = super::serialize(&macaroon).unwrap();
         macaroon = super::deserialize(&serialized).unwrap();
         assert_eq!("http://example.org/", &macaroon.location().unwrap());
-        assert_eq!(&ByteString::from("keyid"), macaroon.identifier());
+        assert_eq!(ByteString::from("keyid"), macaroon.identifier());
         assert_eq!(3, macaroon.caveats().len());
         assert_eq!(
             ByteString::from("account = 3735928559"),

--- a/src/serialization/v2j.rs
+++ b/src/serialization/v2j.rs
@@ -177,13 +177,13 @@ impl Macaroon {
     }
 }
 
-pub fn serialize_v2j(macaroon: &Macaroon) -> Result<Vec<u8>, MacaroonError> {
+pub fn serialize_json(macaroon: &Macaroon) -> Result<Vec<u8>, MacaroonError> {
     let serialized: String =
         serde_json::to_string(&V2JSerialization::from_macaroon(macaroon.clone())?)?;
     Ok(serialized.into_bytes())
 }
 
-pub fn deserialize_v2j(data: &[u8]) -> Result<Macaroon, MacaroonError> {
+pub fn deserialize_json(data: &[u8]) -> Result<Macaroon, MacaroonError> {
     let v2j: V2JSerialization = serde_json::from_slice(data)?;
     Macaroon::from_v2j(v2j)
 }
@@ -205,7 +205,7 @@ mod tests {
     #[test]
     fn test_deserialize_v2j() {
         let serialized_v2j: Vec<u8> = SERIALIZED_V2J.as_bytes().to_vec();
-        let macaroon = super::deserialize_v2j(&serialized_v2j).unwrap();
+        let macaroon = super::deserialize_json(&serialized_v2j).unwrap();
         assert_eq!("http://example.org/", &macaroon.location().unwrap());
         assert_eq!("keyid", macaroon.identifier());
         assert_eq!(2, macaroon.caveats().len());

--- a/src/serialization/v2json.rs
+++ b/src/serialization/v2json.rs
@@ -206,7 +206,7 @@ mod tests {
         let serialized_json: Vec<u8> = SERIALIZED_JSON.as_bytes().to_vec();
         let macaroon = super::deserialize(&serialized_json).unwrap();
         assert_eq!("http://example.org/", &macaroon.location().unwrap());
-        assert_eq!(&ByteString::from("keyid"), macaroon.identifier());
+        assert_eq!(ByteString::from("keyid"), macaroon.identifier());
         assert_eq!(2, macaroon.caveats().len());
         assert_eq!(
             ByteString::from("account = 3735928559"),

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -82,10 +82,10 @@ impl Verifier {
         macaroon: &Macaroon,
     ) -> Result<bool, MacaroonError> {
         let dm = self.discharge_macaroons.clone();
-        let dm_opt = dm.iter().find(|dm| *dm.identifier() == caveat.id());
+        let dm_opt = dm.iter().find(|dm| dm.identifier() == caveat.id());
         match dm_opt {
             Some(dm) => {
-                if self.id_chain.iter().any(|id| id == dm.identifier()) {
+                if self.id_chain.iter().any(|id| id == &dm.identifier()) {
                     info!(
                         "Verifier::verify_caveat: caveat verification loop - id {:?} found in \
                          id chain {:?}",

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -1,10 +1,11 @@
 use caveat;
 use crypto;
 use error::MacaroonError;
+use ByteString;
 use Macaroon;
 
 /// Type of callback for `Verifier::satisfy_general()`
-pub type VerifierCallback = fn(&str) -> bool;
+pub type VerifierCallback = fn(&ByteString) -> bool;
 
 /// Verifier struct
 ///
@@ -12,11 +13,11 @@ pub type VerifierCallback = fn(&str) -> bool;
 /// verification process
 #[derive(Default)]
 pub struct Verifier {
-    predicates: Vec<String>,
+    predicates: Vec<ByteString>,
     callbacks: Vec<VerifierCallback>,
     discharge_macaroons: Vec<Macaroon>,
     signature: [u8; 32],
-    id_chain: Vec<String>,
+    id_chain: Vec<ByteString>,
 }
 
 impl Verifier {
@@ -31,8 +32,8 @@ impl Verifier {
     }
 
     /// Predicate to satisfy a caveat by exact string match
-    pub fn satisfy_exact(&mut self, predicate: &str) {
-        self.predicates.push(String::from(predicate));
+    pub fn satisfy_exact(&mut self, predicate: ByteString) {
+        self.predicates.push(predicate);
     }
 
     /// Provides a callback function used to verify a caveat
@@ -57,7 +58,7 @@ impl Verifier {
         self.signature = generator(&self.signature);
     }
 
-    pub fn verify_predicate(&self, predicate: &str) -> bool {
+    pub fn verify_predicate(&self, predicate: &ByteString) -> bool {
         let mut count = self.predicates.iter().filter(|&p| p == predicate).count();
         if count > 0 {
             return true;
@@ -94,7 +95,7 @@ impl Verifier {
                     return Ok(false);
                 }
                 self.id_chain.push(dm.identifier().clone());
-                let key = crypto::decrypt(self.signature, caveat.verifier_id().as_slice())?;
+                let key = crypto::decrypt(self.signature, &caveat.verifier_id().0)?;
                 dm.verify_as_discharge(self, macaroon, key.as_slice())
             }
             None => {
@@ -115,6 +116,7 @@ mod tests {
 
     use super::Verifier;
     use crypto;
+    use ByteString;
     use Macaroon;
 
     #[test]
@@ -140,7 +142,7 @@ mod tests {
         let serialized = "MDAyMWxvY2F0aW9uIGh0dHA6Ly9leGFtcGxlLm9yZy8KMDAxNWlkZW50aWZpZXIga2V5aWQKMDAxZGNpZCBhY2NvdW50ID0gMzczNTkyODU1OQowMDJmc2lnbmF0dXJlIPVIB_bcbt-Ivw9zBrOCJWKjYlM9v3M5umF2XaS9JZ2HCg";
         let macaroon = Macaroon::deserialize(&serialized.as_bytes().to_vec()).unwrap();
         let mut verifier = Verifier::new();
-        verifier.satisfy_exact("account = 3735928559");
+        verifier.satisfy_exact("account = 3735928559".into());
         let key = crypto::generate_derived_key(b"this is the key");
         assert!(macaroon.verify(&key, &mut verifier).unwrap());
     }
@@ -150,7 +152,7 @@ mod tests {
         let serialized = "MDAyMWxvY2F0aW9uIGh0dHA6Ly9leGFtcGxlLm9yZy8KMDAxNWlkZW50aWZpZXIga2V5aWQKMDAxZGNpZCBhY2NvdW50ID0gMzczNTkyODU1OQowMDJmc2lnbmF0dXJlIPVIB_bcbt-Ivw9zBrOCJWKjYlM9v3M5umF2XaS9JZ2HCg";
         let macaroon = Macaroon::deserialize(&serialized.as_bytes().to_vec()).unwrap();
         let mut verifier = Verifier::new();
-        verifier.satisfy_exact("account = 0000000000");
+        verifier.satisfy_exact("account = 0000000000".into());
         let key = crypto::generate_derived_key(b"this is the key");
         assert!(!macaroon.verify(&key, &mut verifier).unwrap());
     }
@@ -169,8 +171,8 @@ mod tests {
         let serialized = "MDAyMWxvY2F0aW9uIGh0dHA6Ly9leGFtcGxlLm9yZy8KMDAxNWlkZW50aWZpZXIga2V5aWQKMDAxZGNpZCBhY2NvdW50ID0gMzczNTkyODU1OQowMDE1Y2lkIHVzZXIgPSBhbGljZQowMDJmc2lnbmF0dXJlIEvpZ80eoMaya69qSpTumwWxWIbaC6hejEKpPI0OEl78Cg";
         let macaroon = Macaroon::deserialize(&serialized.as_bytes().to_vec()).unwrap();
         let mut verifier = Verifier::new();
-        verifier.satisfy_exact("account = 3735928559");
-        verifier.satisfy_exact("user = alice");
+        verifier.satisfy_exact("account = 3735928559".into());
+        verifier.satisfy_exact("user = alice".into());
         let key = crypto::generate_derived_key(b"this is the key");
         assert!(macaroon.verify(&key, &mut verifier).unwrap());
     }
@@ -180,21 +182,25 @@ mod tests {
         let serialized = "MDAyMWxvY2F0aW9uIGh0dHA6Ly9leGFtcGxlLm9yZy8KMDAxNWlkZW50aWZpZXIga2V5aWQKMDAxZGNpZCBhY2NvdW50ID0gMzczNTkyODU1OQowMDE1Y2lkIHVzZXIgPSBhbGljZQowMDJmc2lnbmF0dXJlIEvpZ80eoMaya69qSpTumwWxWIbaC6hejEKpPI0OEl78Cg";
         let macaroon = Macaroon::deserialize(&serialized.as_bytes().to_vec()).unwrap();
         let mut verifier = Verifier::new();
-        verifier.satisfy_exact("account = 3735928559");
+        verifier.satisfy_exact("account = 3735928559".into());
         let key = crypto::generate_derived_key(b"this is the key");
         assert!(!macaroon.verify(&key, &mut verifier).unwrap());
         let mut verifier = Verifier::new();
-        verifier.satisfy_exact("user = alice");
+        verifier.satisfy_exact("user = alice".into());
         let key = crypto::generate_derived_key(b"this is the key");
         assert!(!macaroon.verify(&key, &mut verifier).unwrap());
     }
 
-    fn after_time_verifier(caveat: &str) -> bool {
-        if !caveat.starts_with("time > ") {
+    fn after_time_verifier(caveat: &ByteString) -> bool {
+        if !caveat.0.starts_with(b"time > ") {
             return false;
         }
+        let strcaveat = match std::str::from_utf8(&caveat.0) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
 
-        match time::strptime(&caveat[7..], "%Y-%m-%dT%H:%M") {
+        match time::strptime(&strcaveat[7..], "%Y-%m-%dT%H:%M") {
             Ok(compare) => time::now() > compare,
             Err(_) => false,
         }
@@ -203,13 +209,13 @@ mod tests {
     #[test]
     fn test_macaroon_two_exact_and_one_general_caveat() {
         let mut macaroon =
-            Macaroon::create("http://example.org/", b"this is the key", "keyid").unwrap();
-        macaroon.add_first_party_caveat("account = 3735928559");
-        macaroon.add_first_party_caveat("user = alice");
-        macaroon.add_first_party_caveat("time > 2010-01-01T00:00");
+            Macaroon::create("http://example.org/", b"this is the key", "keyid".into()).unwrap();
+        macaroon.add_first_party_caveat("account = 3735928559".into());
+        macaroon.add_first_party_caveat("user = alice".into());
+        macaroon.add_first_party_caveat("time > 2010-01-01T00:00".into());
         let mut verifier = Verifier::new();
-        verifier.satisfy_exact("account = 3735928559");
-        verifier.satisfy_exact("user = alice");
+        verifier.satisfy_exact("account = 3735928559".into());
+        verifier.satisfy_exact("user = alice".into());
         verifier.satisfy_general(after_time_verifier);
         let key = crypto::generate_derived_key(b"this is the key");
         assert!(macaroon.verify(&key, &mut verifier).unwrap());
@@ -218,13 +224,13 @@ mod tests {
     #[test]
     fn test_macaroon_two_exact_and_one_general_fails_general() {
         let mut macaroon =
-            Macaroon::create("http://example.org/", b"this is the key", "keyid").unwrap();
-        macaroon.add_first_party_caveat("account = 3735928559");
-        macaroon.add_first_party_caveat("user = alice");
-        macaroon.add_first_party_caveat("time > 3010-01-01T00:00");
+            Macaroon::create("http://example.org/", b"this is the key", "keyid".into()).unwrap();
+        macaroon.add_first_party_caveat("account = 3735928559".into());
+        macaroon.add_first_party_caveat("user = alice".into());
+        macaroon.add_first_party_caveat("time > 3010-01-01T00:00".into());
         let mut verifier = Verifier::new();
-        verifier.satisfy_exact("account = 3735928559");
-        verifier.satisfy_exact("user = alice");
+        verifier.satisfy_exact("account = 3735928559".into());
+        verifier.satisfy_exact("user = alice".into());
         verifier.satisfy_general(after_time_verifier);
         let key = crypto::generate_derived_key(b"this is the key");
         assert!(!macaroon.verify(&key, &mut verifier).unwrap());
@@ -233,28 +239,32 @@ mod tests {
     #[test]
     fn test_macaroon_two_exact_and_one_general_incomplete_verifier() {
         let key = b"this is the key";
-        let mut macaroon = Macaroon::create("http://example.org/", key, "keyid").unwrap();
-        macaroon.add_first_party_caveat("account = 3735928559");
-        macaroon.add_first_party_caveat("user = alice");
-        macaroon.add_first_party_caveat("time > 2010-01-01T00:00");
+        let mut macaroon = Macaroon::create("http://example.org/", key, "keyid".into()).unwrap();
+        macaroon.add_first_party_caveat("account = 3735928559".into());
+        macaroon.add_first_party_caveat("user = alice".into());
+        macaroon.add_first_party_caveat("time > 2010-01-01T00:00".into());
         let mut verifier = Verifier::new();
-        verifier.satisfy_exact("account = 3735928559");
-        verifier.satisfy_exact("user = alice");
+        verifier.satisfy_exact("account = 3735928559".into());
+        verifier.satisfy_exact("user = alice".into());
         assert!(!macaroon.verify(key, &mut verifier).unwrap());
     }
 
     #[test]
     fn test_macaroon_third_party_caveat() {
         let mut macaroon =
-            Macaroon::create("http://example.org/", b"this is the key", "keyid").unwrap();
+            Macaroon::create("http://example.org/", b"this is the key", "keyid".into()).unwrap();
         macaroon.add_third_party_caveat(
             "http://auth.mybank/",
             b"this is another key",
-            "other keyid",
+            "other keyid".into(),
         );
-        let mut discharge =
-            Macaroon::create("http://auth.mybank/", b"this is another key", "other keyid").unwrap();
-        discharge.add_first_party_caveat("time > 2010-01-01T00:00");
+        let mut discharge = Macaroon::create(
+            "http://auth.mybank/",
+            b"this is another key",
+            "other keyid".into(),
+        )
+        .unwrap();
+        discharge.add_first_party_caveat("time > 2010-01-01T00:00".into());
         macaroon.bind(&mut discharge);
         let mut verifier = Verifier::new();
         verifier.satisfy_general(after_time_verifier);
@@ -266,18 +276,22 @@ mod tests {
     #[test]
     fn test_macaroon_third_party_caveat_with_cycle() {
         let mut macaroon =
-            Macaroon::create("http://example.org/", b"this is the key", "keyid").unwrap();
+            Macaroon::create("http://example.org/", b"this is the key", "keyid".into()).unwrap();
         macaroon.add_third_party_caveat(
             "http://auth.mybank/",
             b"this is another key",
-            "other keyid",
+            "other keyid".into(),
         );
-        let mut discharge =
-            Macaroon::create("http://auth.mybank/", b"this is another key", "other keyid").unwrap();
+        let mut discharge = Macaroon::create(
+            "http://auth.mybank/",
+            b"this is another key",
+            "other keyid".into(),
+        )
+        .unwrap();
         discharge.add_third_party_caveat(
             "http://auth.mybank/",
             b"this is another key",
-            "other keyid",
+            "other keyid".into(),
         );
         macaroon.bind(&mut discharge);
         let mut verifier = Verifier::new();


### PR DESCRIPTION
This unexports several publicly exported macaroon functions that were only being used internally (and should probably only be used internally). It also standardizes the deserialization names as part of making some of the functions clearer. These functions were already namespaced by their module name, making suffixes like `v2j` redundant.

It also adds support for arbitrary binary data. Per the [spec](https://github.com/rescrv/libmacaroons/blob/master/doc/format.txt):

> All fields other than the version and location fields may contain arbitrary
> binary data, though per-service conventions are free to impose stricter
> requirements - these are outside the scope of this document.

The current API only supported data that could be parsed as a string. This adds a new `ByteString` type that handles the underlying base64 decoding and encoding as part of its deserializing and serializing. There are also changes to the documentation to capture this change