### PR TITLE
ref(caveat): Refactors caveats to just use a simple enum

### DIFF
--- a/src/serialization/macaroon_builder.rs
+++ b/src/serialization/macaroon_builder.rs
@@ -8,7 +8,7 @@ pub struct MacaroonBuilder {
     identifier: ByteString,
     location: Option<String>,
     signature: [u8; 32],
-    caveats: Vec<Box<dyn Caveat>>,
+    caveats: Vec<Caveat>,
 }
 
 impl MacaroonBuilder {
@@ -32,7 +32,7 @@ impl MacaroonBuilder {
         self.signature.clone_from_slice(signature);
     }
 
-    pub fn add_caveat(&mut self, caveat: Box<dyn Caveat>) {
+    pub fn add_caveat(&mut self, caveat: Caveat) {
         self.caveats.push(caveat);
     }
 

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -58,7 +58,18 @@ impl Verifier {
         self.signature = generator(&self.signature);
     }
 
-    pub fn verify_predicate(&self, predicate: &ByteString) -> bool {
+    pub fn verify(
+        &mut self,
+        caveat: &caveat::Caveat,
+        macaroon: &Macaroon,
+    ) -> Result<bool, MacaroonError> {
+        match caveat {
+            caveat::Caveat::FirstParty(fp) => Ok(self.verify_predicate(&fp.predicate())),
+            caveat::Caveat::ThirdParty(tp) => self.verify_caveat(tp, macaroon),
+        }
+    }
+
+    fn verify_predicate(&self, predicate: &ByteString) -> bool {
         let mut count = self.predicates.iter().filter(|&p| p == predicate).count();
         if count > 0 {
             return true;
@@ -76,9 +87,9 @@ impl Verifier {
         false
     }
 
-    pub fn verify_caveat(
+    fn verify_caveat(
         &mut self,
-        caveat: &caveat::ThirdPartyCaveat,
+        caveat: &caveat::ThirdParty,
         macaroon: &Macaroon,
     ) -> Result<bool, MacaroonError> {
         let dm = self.discharge_macaroons.clone();


### PR DESCRIPTION
The caveats were a bit tangled with a trait implementation and various structs.
This simplifies things down to a single enum of first and third party
caveats and refactors the rest of the code to account for the change